### PR TITLE
Add support for non zero origin for the map, and fix a scaling bug

### DIFF
--- a/src/tile_map.vert
+++ b/src/tile_map.vert
@@ -20,7 +20,7 @@ layout(set = 2, binding = 1) uniform TileMapChunk {
 
 void main() {
     v_Uv = Vertex_Uv;
-    vec3 position = Vertex_Position * vec3(5.0, 5.0, 1.0);
+    vec3 position = Vertex_Position * vec3(4.0, 4.0, 1.0);
     position.z = layer_id;
     gl_Position = ViewProj * Model * vec4(position, 1.0);
 }


### PR DESCRIPTION
The TiledMapComponents bundle now takes a translation which is added to the previous default translation. I don't think it was possible before, but I'm new at this, so I might be wrong.
I also changed the scaling to x4 everywhere, it was previously x4 for map centering and x5 in the .vert file for display. 
The scaling could also be fixed to x5 everywhere, I just changed the one that was simpler. 