### PR TITLE
tiles keep the flip flags until UV ordering happens

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -22,6 +22,9 @@ pub struct Tile {
     pub pos: Vec2,
     pub vertex: Vec4,
     pub uv: Vec4,
+    pub flip_d: bool,
+    pub flip_h: bool,
+    pub flip_v: bool,
 }
 
 #[derive(Debug)]
@@ -215,29 +218,21 @@ impl Map {
                                     };
 
                                     // Calculate UV:
-                                    let mut start_u: f32 = sprite_sheet_x / texture_width;
-                                    let mut end_u: f32 =
+                                    let start_u: f32 = sprite_sheet_x / texture_width;
+                                    let end_u: f32 =
                                         (sprite_sheet_x + tile_width) / texture_width;
-                                    let mut start_v: f32 = sprite_sheet_y / texture_height;
-                                    let mut end_v: f32 =
+                                    let start_v: f32 = sprite_sheet_y / texture_height;
+                                    let end_v: f32 =
                                         (sprite_sheet_y + tile_height) / texture_height;
-
-                                    if map_tile.flip_h {
-                                        let temp_startu = start_u;
-                                        start_u = end_u;
-                                        end_u = temp_startu;
-                                    }
-                                    if map_tile.flip_v {
-                                        let temp_startv = start_v;
-                                        start_v = end_v;
-                                        end_v = temp_startv;
-                                    }
 
                                     Tile {
                                         tile_id: map_tile.gid,
                                         pos: Vec2::new(tile_x as f32, tile_y as f32),
                                         vertex: Vec4::new(start_x, start_y, end_x, end_y),
                                         uv: Vec4::new(start_u, start_v, end_u, end_v),
+                                        flip_d: map_tile.flip_d,
+                                        flip_h: map_tile.flip_h,
+                                        flip_v: map_tile.flip_v,
                                     }
                                 } else {
                                     // Empty tile
@@ -246,6 +241,9 @@ impl Map {
                                         pos: Vec2::new(tile_x as f32, tile_y as f32),
                                         vertex: Vec4::new(0.0, 0.0, 0.0, 0.0),
                                         uv: Vec4::new(0.0, 0.0, 0.0, 0.0),
+                                        flip_d: false,
+                                        flip_h: false,
+                                        flip_v: false,
                                     }
                                 };
 
@@ -293,21 +291,39 @@ impl Map {
                                 continue;
                             }
 
+
                             // X, Y
-                            positions.push([tile.vertex.x(), tile.vertex.y(), 0.0]);
-                            uvs.push([tile.uv.x(), tile.uv.w()]);
-
+                            positions.push([tile.vertex.x, tile.vertex.y, 0.0]);
                             // X, Y + 1
-                            positions.push([tile.vertex.x(), tile.vertex.w(), 0.0]);
-                            uvs.push([tile.uv.x(), tile.uv.y()]);
-
+                            positions.push([tile.vertex.x, tile.vertex.w, 0.0]);
                             // X + 1, Y + 1
-                            positions.push([tile.vertex.z(), tile.vertex.w(), 0.0]);
-                            uvs.push([tile.uv.z(), tile.uv.y()]);
-
+                            positions.push([tile.vertex.z, tile.vertex.w, 0.0]);
                             // X + 1, Y
-                            positions.push([tile.vertex.z(), tile.vertex.y(), 0.0]);
-                            uvs.push([tile.uv.z(), tile.uv.w()]);
+                            positions.push([tile.vertex.z, tile.vertex.y, 0.0]);
+
+                            let mut next_uvs = [ 
+                                // X, Y
+                                [tile.uv.x, tile.uv.w],
+                                // X, Y + 1
+                                [tile.uv.x, tile.uv.y],
+                                // X + 1, Y + 1
+                                [tile.uv.z, tile.uv.y],
+                                // X + 1, Y
+                                [tile.uv.z, tile.uv.w]
+                            ];
+                            if tile.flip_d {
+                                next_uvs.swap(0, 2);
+                            }
+                            if tile.flip_h {
+                                next_uvs.reverse();
+                            }
+                            if tile.flip_v {
+                                next_uvs.reverse();
+                                next_uvs.swap(0, 2);
+                                next_uvs.swap(1, 3);
+                            }
+
+                            next_uvs.iter().for_each(|uv| uvs.push(*uv));
 
                             indices.extend_from_slice(&[i + 0, i + 2, i + 1, i + 0, i + 3, i + 2]);
 


### PR DESCRIPTION
I found that rotation of tiles didn't work except in 180 degree case (both horizontal and vertical flipping). Investigating this issue, I found there was no handling for the diagonal flip bit.

In order to provide for other cases, we can propagate the three flip flags via the Tile object until the section of code where the UV-mapping is applied. Then, reordering of UVs via the procedure set out in the [tiled documentation](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#tile-flipping) results in the correct rotation.