### PR TITLE
Load object groups / objects, and add auto-reload support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,8 +3320,7 @@ dependencies = [
 [[package]]
 name = "tiled"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162eb47ee963888a04affec76e698b93e30dd782f983c21be42423ff3aaccefe"
+source = "git+https://github.com/mattyhall/rs-tiled?branch=master#19c311231f1809491583c1e8e45b142d8ca3fa80"
 dependencies = [
  "base64 0.10.1",
  "libflate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b50c188ff14b5a6efeb38eee8ccbc505cdf61e347a3d5eb04dc55d74ae4f20e"
+checksum = "7a104f276ccf2299596c747b495582c8313bae3eca524bcf66db684848c50be9"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -45,12 +45,13 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.5.8"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb6ec8807cd25b59e6b8100815afc73f54e294f1a425a2e555971969889a8f8"
+checksum = "a75b7e6a93ecd6dbd2c225154d0fa7f86205574ecaa6c87429fb5f66ee677c44"
 dependencies = [
  "getrandom 0.2.0",
  "lazy_static",
+ "version_check",
 ]
 
 [[package]]
@@ -109,15 +110,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_logger"
-version = "0.9.0"
+name = "ansi_term"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5027a747b8132dc36dc894415a300aab31d6489ee788e9ba07bc99558b1278ca"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "android_log-sys 0.2.0",
- "env_logger",
- "lazy_static",
- "log",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -131,6 +129,15 @@ name = "anymap"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
+
+[[package]]
+name = "approx"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arrayvec"
@@ -239,37 +246,11 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "bevy"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8de175e156277bf382d5212e4f580e74caaa62917b5554e12ab2addd87ae789"
+checksum = "c16660356e9a79666848ff247aecaa30d9a7bb233e902035140b32d47d0b1345"
 dependencies = [
- "android_logger 0.9.0",
- "bevy_app",
- "bevy_asset",
- "bevy_audio",
- "bevy_core",
- "bevy_diagnostic",
- "bevy_dynamic_plugin",
- "bevy_ecs",
- "bevy_gilrs",
- "bevy_gltf",
- "bevy_input",
- "bevy_math",
- "bevy_pbr",
- "bevy_property",
- "bevy_render",
- "bevy_scene",
- "bevy_sprite",
- "bevy_tasks",
- "bevy_text",
- "bevy_transform",
- "bevy_type_registry",
- "bevy_ui",
- "bevy_utils",
- "bevy_wgpu",
- "bevy_window",
- "bevy_winit",
- "ndk-glue",
+ "bevy_internal",
 ]
 
 [[package]]
@@ -280,15 +261,13 @@ checksum = "d0b37e032266000f7b62b75b562cdcdccdd655294d26042460fd757daf3a5f82"
 
 [[package]]
 name = "bevy_app"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cdf694a6d588bf46a2a7ae5623f176fc5c4ee4d0d71281fdc25bd263136a14"
+checksum = "d720bb8174ec9a7bc8f745ff821536a1d234d50fed205d2f8dc831e0577f76c9"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
  "bevy_utils",
- "instant",
- "log",
  "serde",
  "wasm-bindgen",
  "web-sys",
@@ -296,21 +275,19 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ed5c0dcf4262387a3917dcf4cd1a7bf9539bac843a6c9653bb56e9d5ef723c"
+checksum = "f91a01d06319758b541ea1ed4a84e5b894194b56ece1fc3d09263e8830f06cdd"
 dependencies = [
  "anyhow",
  "bevy_app",
  "bevy_ecs",
- "bevy_property",
+ "bevy_reflect",
  "bevy_tasks",
- "bevy_type_registry",
  "bevy_utils",
  "crossbeam-channel",
  "downcast-rs",
  "js-sys",
- "log",
  "ndk-glue",
  "notify",
  "parking_lot 0.11.0",
@@ -318,7 +295,6 @@ dependencies = [
  "ron",
  "serde",
  "thiserror",
- "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -326,15 +302,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_audio"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6198d842cc25f77dc828d0ba0ae9b313fd864e18af29f60e9d5319d056f8166"
+checksum = "b2db6b28a59a8941872cefab577544fcc296cfe593ce1c466c572fb22797e526"
 dependencies = [
  "anyhow",
  "bevy_app",
  "bevy_asset",
  "bevy_ecs",
- "bevy_type_registry",
+ "bevy_reflect",
  "bevy_utils",
  "parking_lot 0.11.0",
  "rodio",
@@ -342,97 +318,104 @@ dependencies = [
 
 [[package]]
 name = "bevy_core"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbe690bd67ba93067651604a3da5b314ec4de5417547ad0f1fbd93da541ea30"
+checksum = "918dac4225062e3517b63a186c6a4988eee167c7e90f42eeaa7a3c3943f9a1ff"
 dependencies = [
  "bevy_app",
  "bevy_derive",
  "bevy_ecs",
  "bevy_math",
- "bevy_property",
+ "bevy_reflect",
  "bevy_tasks",
- "bevy_type_registry",
  "bevy_utils",
- "instant",
- "log",
 ]
 
 [[package]]
 name = "bevy_derive"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c18d8de3b2f1c66dbac70fbf82bce0dcbeceecf2356eb1b542c735d5c17e0a0"
+checksum = "96e17d375b833953cf0af3cabdf0aff02360591418e79db954b917bf1e6834fd"
 dependencies = [
  "Inflector",
- "proc-macro-crate",
+ "find-crate",
  "proc-macro2",
  "quote",
  "syn",
- "uuid",
 ]
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e98868df99533447a6ad202e6826fe24cecab80c163c1dcac56b811ea69a9f7"
+checksum = "7db1bd6b45976a460af49ad2e325b5594cd2ef29d153301f598bb0c6c2cfaf23"
 dependencies = [
  "bevy_app",
  "bevy_core",
  "bevy_ecs",
  "bevy_utils",
- "instant",
  "parking_lot 0.11.0",
- "uuid",
 ]
 
 [[package]]
 name = "bevy_dynamic_plugin"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5672a27be1e38e11b6f2f1e1290fde2aa4f074628aad33303953ce881a5a78"
+checksum = "07b9aa16336380773e9bed0f7645f05572bcbe0343b957c86e8cef43abd96abc"
 dependencies = [
  "bevy_app",
  "libloading 0.6.3",
- "log",
 ]
 
 [[package]]
 name = "bevy_ecs"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad8a73ad248ed6c16b1ca53eaedd76ae5aa284aa5c4527f8cf3526b5e3a7fce"
+checksum = "c412b6172d95ae55e405ca54462b0fb252531a4c3a12a5cac9eb533dcb4cf1b2"
 dependencies = [
- "bevy_hecs",
+ "bevy_ecs_macros",
  "bevy_tasks",
  "bevy_utils",
+ "bitflags",
  "downcast-rs",
  "fixedbitset",
- "log",
+ "lazy_static",
  "parking_lot 0.11.0",
  "rand",
+ "serde",
  "thiserror",
 ]
 
 [[package]]
-name = "bevy_gilrs"
-version = "0.3.0"
+name = "bevy_ecs_macros"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255ceb467ab2982a0bd1ef0c49ae557704f99fe11ab990a11492cea2e6d7fd7f"
+checksum = "92628e92dd65cef319dd059d1392a981e0c74a8bdd4889bcbbfac55799fa759b"
+dependencies = [
+ "find-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "bevy_gilrs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfbb39c13a967a2fd462ed691a5a1a49c95463075be3872b582b5d90d7bc218f"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_input",
+ "bevy_utils",
  "gilrs",
- "log",
 ]
 
 [[package]]
 name = "bevy_gltf"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dfa912e7fb0ac140b46e2cdf4f6f5e66e6def8049dc8cee69de9a9bafd1836"
+checksum = "bd4253666139cdc5425d1399a033d7f4eaf685fb914b087b6d5c6a1086432995"
 dependencies = [
  "anyhow",
  "base64 0.12.3",
@@ -441,44 +424,20 @@ dependencies = [
  "bevy_ecs",
  "bevy_math",
  "bevy_pbr",
+ "bevy_reflect",
  "bevy_render",
  "bevy_scene",
  "bevy_transform",
- "bevy_type_registry",
  "gltf",
  "image",
  "thiserror",
 ]
 
 [[package]]
-name = "bevy_hecs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18661dc92bcb6cc1f2f5ad630f3f3eae7b23942860ea6845a2a775b5a1f7564f"
-dependencies = [
- "bevy_hecs_macros",
- "bevy_utils",
- "lazy_static",
- "serde",
-]
-
-[[package]]
-name = "bevy_hecs_macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a85e43b7043183821aa62f09c91164a0aa6de771c5397a7a0d0eaf754cc042a"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "bevy_input"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069dc814211aaf691c9aca9ce97210d3238c19e599dfc2bc50b183fe925f0a00"
+checksum = "4d2589b547ed2e48cc204acc670e8c3002e24ca9cabbe427bb4b31d339f628a1"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -487,19 +446,69 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_math"
-version = "0.3.0"
+name = "bevy_internal"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ff845326919ef68a796ae4740e33356683020756bc1d23b552b9b31a106fd3"
+checksum = "ad383825249f68405bd143d88194fda471ad017baf5c3240870c8c38dad8d47f"
 dependencies = [
+ "bevy_app",
+ "bevy_asset",
+ "bevy_audio",
+ "bevy_core",
+ "bevy_derive",
+ "bevy_diagnostic",
+ "bevy_dynamic_plugin",
+ "bevy_ecs",
+ "bevy_gilrs",
+ "bevy_gltf",
+ "bevy_input",
+ "bevy_log",
+ "bevy_math",
+ "bevy_pbr",
+ "bevy_reflect",
+ "bevy_render",
+ "bevy_scene",
+ "bevy_sprite",
+ "bevy_tasks",
+ "bevy_text",
+ "bevy_transform",
+ "bevy_ui",
+ "bevy_utils",
+ "bevy_wgpu",
+ "bevy_window",
+ "bevy_winit",
+ "ndk-glue",
+]
+
+[[package]]
+name = "bevy_log"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "463bf6a1e09f5738b5e3ab7e266ecd59dcd6cfc1d4bd9e9eb5a80825fd80e8ff"
+dependencies = [
+ "android_log-sys 0.2.0",
+ "bevy_app",
+ "bevy_utils",
+ "console_error_panic_hook",
+ "tracing-subscriber",
+ "tracing-wasm",
+]
+
+[[package]]
+name = "bevy_math"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee6066dc393c913f3eb8873c3d3978010b1664b5947f6fa38c28be326da9735"
+dependencies = [
+ "bevy_reflect",
  "glam",
 ]
 
 [[package]]
 name = "bevy_pbr"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e4185bf49b2cfd31a0aec90722b3e898b37de5d61ec4cc53e5df9ecae19d71"
+checksum = "eadb5c93f5257279d2c88879e251c5064e244e88e288a7f640f986f04d0f046e"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -507,46 +516,49 @@ dependencies = [
  "bevy_derive",
  "bevy_ecs",
  "bevy_math",
- "bevy_property",
+ "bevy_reflect",
  "bevy_render",
  "bevy_transform",
- "bevy_type_registry",
  "bevy_window",
 ]
 
 [[package]]
-name = "bevy_property"
-version = "0.3.0"
+name = "bevy_reflect"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd127fa915b12581aab82cf77ade4a29c1a7b00c19672b88c187c14d111227c"
+checksum = "511b41d40080cfb389b2b4d489c0ee0db9e66f09e88fa4ff6faef22c4610e777"
 dependencies = [
+ "bevy_app",
  "bevy_ecs",
- "bevy_math",
- "bevy_property_derive",
+ "bevy_reflect_derive",
  "bevy_utils",
+ "downcast-rs",
  "erased-serde",
- "ron",
+ "glam",
+ "parking_lot 0.11.0",
  "serde",
  "smallvec 1.4.2",
+ "thiserror",
 ]
 
 [[package]]
-name = "bevy_property_derive"
-version = "0.3.0"
+name = "bevy_reflect_derive"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c7a3bc30a90561dc05e662597d595d29a9a7171fb7e5fc34fdb09e4c60c10f"
+checksum = "b40373d356ab3d8aac58c79dc3a56338f56632b55435f73fd009bc6f93ddddc0"
 dependencies = [
- "proc-macro-crate",
+ "find-crate",
  "proc-macro2",
  "quote",
  "syn",
+ "uuid",
 ]
 
 [[package]]
 name = "bevy_render"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c1e99851a90fba39994aa26887da114cb53388e1ba7324b60cea4156351ad23"
+checksum = "f36bfed7edfcf8989e683e122df5384efdf15fd3237fdc2367191ce4722fe374"
 dependencies = [
  "anyhow",
  "bevy-glsl-to-spirv",
@@ -556,9 +568,8 @@ dependencies = [
  "bevy_derive",
  "bevy_ecs",
  "bevy_math",
- "bevy_property",
+ "bevy_reflect",
  "bevy_transform",
- "bevy_type_registry",
  "bevy_utils",
  "bevy_window",
  "bitflags",
@@ -566,7 +577,6 @@ dependencies = [
  "hex",
  "hexasphere",
  "image",
- "log",
  "once_cell",
  "parking_lot 0.11.0",
  "serde",
@@ -574,21 +584,20 @@ dependencies = [
  "smallvec 1.4.2",
  "spirv-reflect",
  "thiserror",
- "uuid",
 ]
 
 [[package]]
 name = "bevy_scene"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d00a586fa10ea919800eda837f98396b49b99a84ee1fc8d6ad4ede151d3b9e4"
+checksum = "f3566aa31189d212785a902d49bf5d75aba32f633d531fe3f4ccf2e51715c7cc"
 dependencies = [
  "anyhow",
  "bevy_app",
  "bevy_asset",
  "bevy_ecs",
- "bevy_property",
- "bevy_type_registry",
+ "bevy_reflect",
+ "bevy_transform",
  "bevy_utils",
  "parking_lot 0.11.0",
  "ron",
@@ -599,54 +608,59 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15eb21af28740fcaf9bd4cec1df90a3015ffab1d33d51022ebc9f106f55210d8"
+checksum = "0b89d4c644e8892f5b215d812c66fd42eb553352288e668076ee25068877e508"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_core",
  "bevy_ecs",
  "bevy_math",
+ "bevy_reflect",
  "bevy_render",
  "bevy_transform",
- "bevy_type_registry",
  "bevy_utils",
  "guillotiere",
  "rectangle-pack",
+ "serde",
  "thiserror",
 ]
 
 [[package]]
 name = "bevy_tasks"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c39e34a30611a1c4a80a30d252f0c53afa27e9500fa73dae1dca2e41c85c765"
+checksum = "73cb02453fab099d690d08f1688f91cd026f0f9f2d06d25629eed9d8b4418d58"
 dependencies = [
  "async-channel",
  "async-executor",
  "event-listener",
  "futures-lite",
+ "instant",
  "num_cpus",
  "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "bevy_text"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b128707cbbc841fa8aa3b41e29362d4a7ba38fb4450b7766d3ff9884389766"
+checksum = "636546e42b1f8c5225f89c0408031e6e2c8c47fe2c06f611d4a678e722ec56c1"
 dependencies = [
  "ab_glyph",
  "anyhow",
  "bevy_app",
  "bevy_asset",
  "bevy_core",
+ "bevy_ecs",
  "bevy_math",
+ "bevy_reflect",
  "bevy_render",
  "bevy_sprite",
- "bevy_type_registry",
  "bevy_utils",
+ "glyph_brush_layout",
+ "thiserror",
 ]
 
 [[package]]
@@ -655,48 +669,30 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bevy",
- "bevy_type_registry",
+ "bevy_reflect",
  "glam",
  "tiled",
 ]
 
 [[package]]
 name = "bevy_transform"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b3c44fc53eb744fc16edc923655a50a01fd0e8e6edfe6f3b3065997e913f5"
+checksum = "2655003cdb139b55ff2851b07345b83e910d7350c466635ad5db1a38169d2c56"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_math",
- "bevy_property",
- "bevy_type_registry",
+ "bevy_reflect",
  "bevy_utils",
- "log",
  "smallvec 1.4.2",
 ]
 
 [[package]]
-name = "bevy_type_registry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aac65e5c297e547844cb5986da14975181a352f532c8d6fe95f7b62e5a40d32"
-dependencies = [
- "bevy_app",
- "bevy_derive",
- "bevy_ecs",
- "bevy_property",
- "bevy_utils",
- "parking_lot 0.11.0",
- "serde",
- "uuid",
-]
-
-[[package]]
 name = "bevy_ui"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2994737dd6413028a2bcda7315ab6cbe8c30c1dab809fb3de4b1e1a8e2fbfabc"
+checksum = "4bc722420aa0d2a8eb10ba5dd7b5aa2181d37e64d71a58df13fb461551c1278c"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -705,31 +701,35 @@ dependencies = [
  "bevy_ecs",
  "bevy_input",
  "bevy_math",
+ "bevy_reflect",
  "bevy_render",
  "bevy_sprite",
  "bevy_text",
  "bevy_transform",
- "bevy_type_registry",
  "bevy_utils",
  "bevy_window",
+ "serde",
  "stretch",
 ]
 
 [[package]]
 name = "bevy_utils"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554cd4eba4b278f6cc0fe5da0b7dbe8deba51613e6769f93b0d5a8a32eac54b6"
+checksum = "4e864ce079f076445c5fb0024f0762de5a617a3572f7ea15c015c9171bc124fd"
 dependencies = [
  "ahash",
  "getrandom 0.2.0",
+ "instant",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "bevy_wgpu"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba8d9ae1409735ddc2b83426849ba819699288d0ff1166b9caa352511300a1d"
+checksum = "34f4ca70078bb827970bbb8fcd56245d98c66012e9136256373de70be1f68d39"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -743,30 +743,28 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",
  "futures-lite",
- "log",
  "parking_lot 0.11.0",
  "wgpu",
 ]
 
 [[package]]
 name = "bevy_window"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f15434d9c46bfc96d449a121e01139489ddc9e79b879edee73c58f90b6b2bbb3"
+checksum = "60c2b78591e1bf568d1aa9f663b6179d17ecf33517f7ac382981bcd7b47d8036"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_math",
  "bevy_utils",
- "uuid",
  "web-sys",
 ]
 
 [[package]]
 name = "bevy_winit"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd72a8a4b42e975c2cac508500471b468568f042d6bbaf6f200844eba3192b0"
+checksum = "9c4c23da1c3502e5e4344cd7a9bf5c1567471dfd633c3f8e0c8ccebf1dcfafed"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -774,7 +772,6 @@ dependencies = [
  "bevy_math",
  "bevy_utils",
  "bevy_window",
- "log",
  "wasm-bindgen",
  "web-sys",
  "winit",
@@ -879,6 +876,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "chunked_transfer"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "cocoa"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54201c07dcf3a5ca33fececb8042aed767ee4bfd5a0235a8ceabcda956044b2"
+checksum = "6f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832"
 dependencies = [
  "bitflags",
  "block",
@@ -952,6 +962,12 @@ dependencies = [
  "libc",
  "objc",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
@@ -984,6 +1000,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
 dependencies = [
  "cache-padded",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+dependencies = [
+ "cfg-if 0.1.10",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1339,6 +1365,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-crate"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057a1d48e8ff33649ee2d7c510b79ecf1f8a52b684d446a72de600ad7e2823b6"
+dependencies = [
+ "toml",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +1562,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generator"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustc_version",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1737,11 +1785,12 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "glam"
-version = "0.9.5"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8637c7ec4fd0776c51eeab3e0d5d1aa7e440ece3fc2ee7d674e13c957287bfc1"
+checksum = "bef81f244b2a421ddb8ccb382857772379c0996fe5948992db5bee51cef3c28e"
 dependencies = [
  "serde",
+ "version_check",
 ]
 
 [[package]]
@@ -1786,6 +1835,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "glyph_brush_layout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bc06d530bf20c1902f1b02799ab7372ff43f6119770c49b0bc3f21bd148820"
+dependencies = [
+ "ab_glyph",
+ "approx",
+ "xi-unicode",
+]
+
+[[package]]
 name = "guillotiere"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,9 +1872,9 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "hexasphere"
-version = "1.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ad921775e70efb68429688766ca130de39af65d5201db760b0e6558bfa8175"
+checksum = "b81ef4574a098bd48fad1a5cd7c4e6e908ac9a90d85338cef224be96f3059355"
 dependencies = [
  "glam",
  "lazy_static",
@@ -1859,12 +1919,13 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.23.9"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974e194911d1f7efe3cd8a8f9db3b767e43536327e899e8bc9a12ef5711b74d2"
+checksum = "7ce04077ead78e39ae8610ad26216aed811996b043d47beed5090db674f9e9b5"
 dependencies = [
  "bytemuck",
  "byteorder",
+ "color_quant",
  "num-iter",
  "num-rational",
  "num-traits",
@@ -2017,9 +2078,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lazycell"
@@ -2109,6 +2167,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+dependencies = [
+ "cfg-if 0.1.10",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "mach"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2204,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2280,7 +2360,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf399b8b7a39c6fb153c4ec32c72fd5fe789df24a647f229c239aa7adb15241"
 dependencies = [
- "android_logger 0.8.6",
+ "android_logger",
  "lazy_static",
  "libc",
  "log",
@@ -2514,9 +2594,9 @@ checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb477c7fd2a3a6e04e1dc6ca2e4e9b04f2df702021dc5a5d1cf078c587dc59f7"
+checksum = "1035b3031937401c4d01719ec82c558b268f923dcfca86e0fb1c2701782b2e89"
 dependencies = [
  "ttf-parser",
 ]
@@ -2782,6 +2862,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,6 +2980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scoped_threadpool"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,9 +3061,9 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "shaderc"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b8aeaae10b9bda5cba66736a7e265f67698e912e1cc6a4678acba286e22be9"
+checksum = "03f0cb8d1f8667fc9c50d5054be830a117af5f9a15f87c66b72bbca0c2fca484"
 dependencies = [
  "libc",
  "shaderc-sys",
@@ -2975,12 +3071,22 @@ dependencies = [
 
 [[package]]
 name = "shaderc-sys"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b12d7c62d6732884c9dfab587503fa3a795b108df152415a89da23812d4737e"
+checksum = "c89175f80244b82f882033a81bd188f87307c4c39b2fe8d0f194314f270bdea9"
 dependencies = [
  "cmake",
  "libc",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
+dependencies = [
+ "lazy_static",
+ "loom",
 ]
 
 [[package]]
@@ -3256,23 +3362,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
  "cfg-if 0.1.10",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.16"
+name = "tracing-attributes"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcf46c1f1f06aeea2d6b81f3c863d0930a596c86ad1920d4e5bad6dd1d7119a"
+checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
-name = "ttf-parser"
-version = "0.8.2"
+name = "tracing-log"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d973cfa0e6124166b50a1105a67c85de40bbc625082f35c0f56f84cb1fb0a827"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec 1.4.2",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
+name = "tracing-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd96394d3d2f119de6c1078fa065b99217db4377f9aac6e87f8393276a0d7962"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ttf-parser"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ddb402ac6c2af6f7a2844243887631c4e94b51585b229fcfddb43958cd55ca"
 
 [[package]]
 name = "typed-arena"
@@ -3621,9 +3793,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winit"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bc559da567d8aa671bbcd08304d49e982c7bf2cb91e10288b9188931c1b772"
+checksum = "da4eda6fce0eb84bd0a33e3c8794eb902e1033d0a1d5a31bc4f19b1b4bbff597"
 dependencies = [
  "bitflags",
  "cocoa",
@@ -3699,6 +3871,12 @@ checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "xi-unicode"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ anyhow = "1.0"
 bevy = "0.4.0"
 bevy_reflect = "0.4.0"
 glam = "0.11.2"
-tiled = "0.9"
-# tiled = { git = "https://github.com/mattyhall/rs-tiled" }
+#tiled = "0.9"
+tiled = { git = "https://github.com/dmtaub/rs-tiled", branch = "patch-1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ exclude = [
 
 [dependencies]
 anyhow = "1.0"
-bevy = "0.3"
-bevy_type_registry = "0.3"
-glam = "0.9"
+bevy = "0.4.0"
+bevy_reflect = "0.4.0"
+glam = "0.11.2"
 tiled = "0.9"
 # tiled = { git = "https://github.com/mattyhall/rs-tiled" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ bevy = "0.4.0"
 bevy_reflect = "0.4.0"
 glam = "0.11.2"
 #tiled = "0.9"
-tiled = { git = "https://github.com/dmtaub/rs-tiled", branch = "patch-1" }
+tiled = { git = "https://github.com/mattyhall/rs-tiled", branch = "master" }

--- a/examples/iso_main.rs
+++ b/examples/iso_main.rs
@@ -10,7 +10,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(bevy_tiled_prototype::TiledMapComponents {
             map_asset: asset_server.load("iso-map.tmx"),
@@ -18,7 +18,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             origin: Transform::from_scale(Vec3::new(4.0, 4.0, 1.0)),
             ..Default::default()
         })
-        .spawn(Camera2dComponents::default());
+        .spawn(Camera2dBundle::default());
 }
 
 fn camera_movement(
@@ -28,7 +28,7 @@ fn camera_movement(
 ) {
     for (_, mut transform) in query.iter_mut() {
         let mut direction = Vec3::zero();
-        let scale = transform.scale.x();
+        let scale = transform.scale.x;
 
         if keyboard_input.pressed(KeyCode::A) {
             direction -= Vec3::new(1.0, 0.0, 0.0);
@@ -56,6 +56,6 @@ fn camera_movement(
             transform.scale = Vec3::new(scale, scale, scale);
         }
 
-        transform.translation += time.delta_seconds * direction * 1000.;
+        transform.translation += time.delta_seconds() * direction * 1000.;
     }
 }

--- a/examples/ortho_main.rs
+++ b/examples/ortho_main.rs
@@ -10,7 +10,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+fn setup(commands: &mut Commands, asset_server: Res<AssetServer>) {
     commands
         .spawn(bevy_tiled_prototype::TiledMapComponents {
             map_asset: asset_server.load("ortho-map.tmx"),
@@ -18,7 +18,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             origin: Transform::from_scale(Vec3::new(4.0, 4.0, 1.0)),
             ..Default::default()
         })
-        .spawn(Camera2dComponents::default());
+        .spawn(Camera2dBundle::default());
 }
 
 fn camera_movement(
@@ -28,7 +28,7 @@ fn camera_movement(
 ) {
     for (_, mut transform) in query.iter_mut() {
         let mut direction = Vec3::zero();
-        let scale = transform.scale.x();
+        let scale = transform.scale.x;
 
         if keyboard_input.pressed(KeyCode::A) {
             direction -= Vec3::new(1.0, 0.0, 0.0);
@@ -56,6 +56,6 @@ fn camera_movement(
             transform.scale = Vec3::new(scale, scale, scale);
         }
 
-        transform.translation += time.delta_seconds * direction * 1000.;
+        transform.translation += time.delta_seconds() * direction * 1000.;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ impl Plugin for TiledMapPlugin {
     fn build(&self, app: &mut AppBuilder) {
         app.add_asset::<map::Map>()
             .init_asset_loader::<loader::TiledMapLoader>()
+            .add_event::<ObjectReadyEvent>()
             .add_system(process_loaded_tile_maps.system());
 
         let resources = app.resources();

--- a/src/map.rs
+++ b/src/map.rs
@@ -409,6 +409,7 @@ pub struct Object {
     pub shape: tiled::ObjectShape,
     pub position: Vec2,
     pub name: String,
+    visible: bool,
     gid: u32, // sprite ID from tiled::Object
     tileset_gid: Option<u32>, // AKA first_gid
     sprite_index: Option<u32>,
@@ -416,10 +417,11 @@ pub struct Object {
 
 impl Object {
     pub fn new(original_object: &tiled::Object) -> Object {
-        // println!("obj {}", original_object.gid.to_string());
+        // println!("obj {} {}", original_object.name, original_object.visible.to_string());
         Object {
             shape: original_object.shape.clone(),
             gid: original_object.gid, // zero for most non-tile objects
+            visible: original_object.visible,
             tileset_gid: None,
             sprite_index: None,
             position: Vec2::new(original_object.x, original_object.y),
@@ -524,6 +526,11 @@ impl Object {
                     texture_atlas: texture_atlas.clone(),
                     sprite: TextureAtlasSprite {
                         index: sprite_index,
+                        ..Default::default()
+                    },
+                    visible: Visible {
+                        is_visible: self.visible.clone(),
+                        is_transparent: true,
                         ..Default::default()
                     },
                     ..Default::default()

--- a/src/map.rs
+++ b/src/map.rs
@@ -409,7 +409,7 @@ pub struct Object {
     pub shape: tiled::ObjectShape,
     pub position: Vec2,
     pub name: String,
-    visible: bool,
+    pub visible: bool,
     gid: u32, // sprite ID from tiled::Object
     tileset_gid: Option<u32>, // AKA first_gid
     sprite_index: Option<u32>,

--- a/src/map.rs
+++ b/src/map.rs
@@ -13,7 +13,7 @@ use glam::Vec2;
 use std::{io::BufReader, path::Path};
 
 #[derive(Debug)]
-pub struct BevyTile {
+pub struct Tile {
     pub tile_id: u32,
     pub pos: Vec2,
     pub vertex: Vec4,
@@ -21,35 +21,35 @@ pub struct BevyTile {
 }
 
 #[derive(Debug)]
-pub struct BevyChunk {
+pub struct Chunk {
     pub position: Vec2,
-    pub tiles: Vec<Vec<BevyTile>>,
+    pub tiles: Vec<Vec<Tile>>,
 }
 
 #[derive(Debug)]
 pub struct TilesetLayer {
     pub tile_size: Vec2,
-    pub chunks: Vec<Vec<BevyChunk>>,
+    pub chunks: Vec<Vec<Chunk>>,
     pub tileset_guid: u32,
 }
 
 #[derive(Debug)]
-pub struct BevyLayer {
+pub struct Layer {
     pub tileset_layers: Vec<TilesetLayer>,
 }
 
 // An asset for maps
 #[derive(Debug, TypeUuid)]
 #[uuid = "5f6fbac8-3f52-424e-a928-561667fea074"]
-pub struct BevyMap {
+pub struct Map {
     pub map: tiled::Map,
     pub meshes: Vec<(u32, u32, Mesh)>,
-    pub layers: Vec<BevyLayer>,
+    pub layers: Vec<Layer>,
     pub tile_size: Vec2,
     pub image_folder: std::path::PathBuf,
 }
 
-impl BevyMap {
+impl Map {
     pub fn project_ortho(pos: Vec2, tile_width: f32, tile_height: f32) -> Vec2 {
         let x = tile_width * pos.x;
         let y = tile_height * pos.y;
@@ -77,13 +77,13 @@ impl BevyMap {
         let map_center = Vec2::new(self.map.width as f32 / 2.0, self.map.height as f32 / 2.0);
         match self.map.orientation {
             tiled::Orientation::Orthogonal => {
-                let center = BevyMap::project_ortho(map_center, tile_size.x, tile_size.y);
+                let center = Map::project_ortho(map_center, tile_size.x, tile_size.y);
                 Transform::from_matrix(
                     origin.compute_matrix() * Mat4::from_translation(-center.extend(0.0)),
                 )
             }
             tiled::Orientation::Isometric => {
-                let center = BevyMap::project_iso(map_center, tile_size.x, tile_size.y);
+                let center = Map::project_iso(map_center, tile_size.x, tile_size.y);
                 Transform::from_matrix(
                     origin.compute_matrix() * Mat4::from_translation(-center.extend(0.0)),
                 )
@@ -92,7 +92,7 @@ impl BevyMap {
         }
     }
 
-    pub fn try_from_bytes(asset_path: &Path, bytes: Vec<u8>) -> Result<BevyMap> {
+    pub fn try_from_bytes(asset_path: &Path, bytes: Vec<u8>) -> Result<Map> {
         let map = tiled::parse_with_path(BufReader::new(bytes.as_slice()), asset_path).unwrap();
 
         let mut layers = Vec::new();
@@ -168,7 +168,7 @@ impl BevyMap {
                                     // Calculate positions
                                     let (start_x, end_x, start_y, end_y) = match map.orientation {
                                         tiled::Orientation::Orthogonal => {
-                                            let center = BevyMap::project_ortho(
+                                            let center = Map::project_ortho(
                                                 Vec2::new(lookup_x as f32, lookup_y as f32),
                                                 tile_width,
                                                 tile_height,
@@ -187,7 +187,7 @@ impl BevyMap {
                                             (start.x, end.x, start.y, end.y)
                                         }
                                         tiled::Orientation::Isometric => {
-                                            let center = BevyMap::project_iso(
+                                            let center = Map::project_iso(
                                                 Vec2::new(lookup_x as f32, lookup_y as f32),
                                                 tile_width,
                                                 tile_height,
@@ -229,7 +229,7 @@ impl BevyMap {
                                         end_v = temp_startv;
                                     }
 
-                                    BevyTile {
+                                    Tile {
                                         tile_id: map_tile.gid,
                                         pos: Vec2::new(tile_x as f32, tile_y as f32),
                                         vertex: Vec4::new(start_x, start_y, end_x, end_y),
@@ -237,7 +237,7 @@ impl BevyMap {
                                     }
                                 } else {
                                     // Empty tile
-                                    BevyTile {
+                                    Tile {
                                         tile_id: 0,
                                         pos: Vec2::new(tile_x as f32, tile_y as f32),
                                         vertex: Vec4::new(0.0, 0.0, 0.0, 0.0),
@@ -250,7 +250,7 @@ impl BevyMap {
                             tiles.push(tiles_y);
                         }
 
-                        let chunk = BevyChunk {
+                        let chunk = Chunk {
                             position: Vec2::new(chunk_x as f32, chunk_y as f32),
                             tiles,
                         };
@@ -267,7 +267,7 @@ impl BevyMap {
                 tileset_layers.push(tileset_layer);
             }
 
-            let layer = BevyLayer { tileset_layers };
+            let layer = Layer { tileset_layers };
             layers.push(layer);
         }
 
@@ -325,7 +325,7 @@ impl BevyMap {
             }
         }
 
-        let map = BevyMap {
+        let map = Map {
             map,
             meshes,
             layers,
@@ -343,7 +343,7 @@ pub struct TiledMapCenter(pub bool);
 /// A bundle of tiled map entities.
 #[derive(Bundle)]
 pub struct TiledMapComponents {
-    pub map_asset: Handle<BevyMap>,
+    pub map_asset: Handle<Map>,
     pub materials: HashMap<u32, Handle<ColorMaterial>>,
     pub origin: Transform,
     pub center: TiledMapCenter,
@@ -362,7 +362,7 @@ impl Default for TiledMapComponents {
 
 #[derive(Default)]
 pub struct MapResourceProviderState {
-    map_event_reader: EventReader<AssetEvent<BevyMap>>,
+    map_event_reader: EventReader<AssetEvent<Map>>,
 }
 
 #[derive(Bundle)]
@@ -403,19 +403,19 @@ pub fn process_loaded_tile_maps(
     commands: &mut Commands,
     asset_server: Res<AssetServer>,
     mut state: Local<MapResourceProviderState>,
-    map_events: Res<Events<AssetEvent<BevyMap>>>,
-    mut maps: ResMut<Assets<BevyMap>>,
+    map_events: Res<Events<AssetEvent<Map>>>,
+    mut maps: ResMut<Assets<Map>>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<ColorMaterial>>,
     mut query: Query<(
         Entity,
         &TiledMapCenter,
-        &Handle<BevyMap>,
+        &Handle<Map>,
         &mut HashMap<u32, Handle<ColorMaterial>>,
         &Transform,
     )>,
 ) {
-    let mut changed_maps = HashSet::<Handle<BevyMap>>::default();
+    let mut changed_maps = HashSet::<Handle<Map>>::default();
     for event in state.map_event_reader.iter(&map_events) {
         match event {
             AssetEvent::Created { handle } => {
@@ -432,7 +432,7 @@ pub fn process_loaded_tile_maps(
         }
     }
 
-    let mut new_meshes = HashMap::<&Handle<BevyMap>, Vec<(u32, u32, Handle<Mesh>)>>::default();
+    let mut new_meshes = HashMap::<&Handle<Map>, Vec<(u32, u32, Handle<Mesh>)>>::default();
     for changed_map in changed_maps.iter() {
         let map = maps.get_mut(changed_map).unwrap();
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -623,16 +623,20 @@ pub fn process_loaded_tile_maps(
                         let columns = (texture_width / tile_width).floor() as usize;
                         let rows = (texture_height / tile_height).floor() as usize;
 
-                        let atlas = TextureAtlas::from_grid(
-                            texture_handle.clone(),
-                            Vec2::new(tile_width, tile_height),
-                            columns,
-                            rows
-                        );
-                        let atlas_handle = texture_atlases.add(atlas);
-                        for i in 0..(columns * rows) as u32 {
-                            // println!("insert: {}", tileset.first_gid + i);
-                            texture_atlas_map.insert(tileset.first_gid + i, atlas_handle.clone());
+                        let has_new = (0..(columns*rows) as u32).fold(false, |total, next | total || !texture_atlas_map.contains_key(&(tileset.first_gid + next)));
+                        if has_new {
+                            let atlas = TextureAtlas::from_grid(
+                                texture_handle.clone(),
+                                Vec2::new(tile_width, tile_height),
+                                columns,
+                                rows
+                            );
+                            let atlas_handle = texture_atlases.add(atlas);
+                            for i in 0..(columns * rows) as u32 {
+                                if texture_atlas_map.contains_key(&(tileset.first_gid + i)) { continue; }
+                                // println!("insert: {}", tileset.first_gid + i);
+                                texture_atlas_map.insert(tileset.first_gid + i, atlas_handle.clone());
+                            }
                         }
                     }
                 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -364,11 +364,18 @@ impl Object {
         self.sprite_index = self.tileset_gid.map(|first_gid| &self.gid - first_gid );
     }
     // for now this is here, but it should be in the consuming application
-    pub fn spawn_sprite(&self, commands: &mut Commands, texture_atlas: Option<&Handle<TextureAtlas>> ) {
+    pub fn spawn_sprite(&self,
+        commands: &mut Commands,
+        texture_atlas: Option<&Handle<TextureAtlas>>,
+        map_transform: &Transform,
+    ) {
         match (texture_atlas, self.sprite_index) {
             (Some(texture_atlas), Some(sprite_index)) => {
+                let mut sprite_transform = map_transform.clone();
+                sprite_transform.translation += Vec3::new(self.position.x, self.position.y, 0.01);
+    
                 commands.spawn(SpriteSheetBundle {
-                    // transform: sprite_transform,
+                    transform: sprite_transform,
                     texture_atlas: texture_atlas.clone(),
                     sprite: TextureAtlasSprite {
                         index: sprite_index,
@@ -606,7 +613,7 @@ pub fn process_loaded_tile_maps(
                         tiled::ObjectShape::Rect { width: _, height: _ } => {
                             new_object.set_tile_ids(&tile_gids);
                             new_object.tileset_gid.map(|tileset_gid| {
-                                new_object.spawn_sprite(commands, texture_atlas_map.get(&tileset_gid))
+                                new_object.spawn_sprite(commands, texture_atlas_map.get(&tileset_gid), &tile_map_transform)
                             });
                         }
                         tiled::ObjectShape::Ellipse { width: _ , height: _ } => {}

--- a/src/map.rs
+++ b/src/map.rs
@@ -10,7 +10,7 @@ use bevy_reflect::TypeUuid;
 
 use crate::{loader::TiledMapLoader, TileMapChunk, TILE_MAP_PIPELINE_HANDLE};
 use glam::Vec2;
-use std::{io::BufReader, path::Path};
+use std::{io::BufReader, path::{Path, PathBuf}};
 
 pub use tiled::ObjectShape;
 
@@ -53,6 +53,7 @@ pub struct Map {
     pub groups: Vec<ObjectGroup>,
     pub tile_size: Vec2,
     pub image_folder: std::path::PathBuf,
+    pub asset_dependencies: Vec<PathBuf>,
 }
 
 impl Map {
@@ -132,6 +133,8 @@ impl Map {
         let chunk_size_x = (map.width as f32 / target_chunk_x as f32).ceil().max(1.0) as usize;
         let chunk_size_y = (map.height as f32 / target_chunk_y as f32).ceil().max(1.0) as usize;
         let tile_size = Vec2::new(map.tile_width as f32, map.tile_height as f32);
+        let image_folder: PathBuf = asset_path.parent().unwrap().into();
+        let mut asset_dependencies = Vec::new();
 
         for layer in map.layers.iter() {
             if !layer.visible {
@@ -146,6 +149,9 @@ impl Map {
                 let texture_width = image.width as f32;
                 let texture_height = image.height as f32;
                 let columns = (texture_width / tile_width).floor();
+
+                let tile_path = image_folder.join(tileset.images.first().unwrap().source.as_str());
+                asset_dependencies.push(tile_path);
 
                 let mut chunks = Vec::new();
                 // 32 x 32 tile chunk sizes
@@ -373,7 +379,8 @@ impl Map {
             layers,
             groups,
             tile_size,
-            image_folder: asset_path.parent().unwrap().into(),
+            image_folder,
+            asset_dependencies,
         };
 
         Ok(map)

--- a/src/map.rs
+++ b/src/map.rs
@@ -426,6 +426,11 @@ impl Object {
             name: original_object.name.clone()
         }
     }
+
+    pub fn is_shape(&self) -> bool {
+        self.tileset_gid.is_none()
+    }
+
     pub fn new_with_tile_ids(original_object: &tiled::Object, tile_gids: &HashMap<u32, u32>) -> Object {
         // println!("obj {}", original_object.gid.to_string());
         let mut o = Object::new(original_object);

--- a/src/map.rs
+++ b/src/map.rs
@@ -407,6 +407,7 @@ impl ObjectGroup {
 pub struct Object {
     pub shape: tiled::ObjectShape,
     pub position: Vec2,
+    pub name: String,
     gid: u32, // sprite ID from tiled::Object
     tileset_gid: Option<u32>, // AKA first_gid
     sprite_index: Option<u32>,
@@ -421,7 +422,7 @@ impl Object {
             tileset_gid: None,
             sprite_index: None,
             position: Vec2::new(original_object.x, original_object.y),
-//            map_id: Handle<Map>
+            name: original_object.name.clone()
         }
     }
     pub fn create(original_object: &tiled::Object, tile_gids: &HashMap<u32, u32>) -> Object {

--- a/src/map.rs
+++ b/src/map.rs
@@ -12,6 +12,8 @@ use crate::{loader::TiledMapLoader, TileMapChunk, TILE_MAP_PIPELINE_HANDLE};
 use glam::Vec2;
 use std::{io::BufReader, path::Path};
 
+pub use tiled::ObjectShape;
+
 #[derive(Debug)]
 pub struct Tile {
     pub tile_id: u32,
@@ -384,8 +386,8 @@ pub struct TiledMapCenter(pub bool);
 pub struct ObjectGroup {
     name: String,
     opacity: f32,
-    visible: bool,
-    objects: Vec<Object>,
+    pub visible: bool,
+    pub objects: Vec<Object>,
 }
 
 
@@ -403,8 +405,8 @@ impl ObjectGroup {
 
 #[derive(Debug)]
 pub struct Object {
-    shape: tiled::ObjectShape,
-    position: Vec2,
+    pub shape: tiled::ObjectShape,
+    pub position: Vec2,
     gid: u32, // sprite ID from tiled::Object
     tileset_gid: Option<u32>, // AKA first_gid
     sprite_index: Option<u32>,
@@ -522,7 +524,7 @@ impl Default for TiledMapComponents {
 
 #[derive(Default)]
 pub struct MapResourceProviderState {
-    map_event_reader: EventReader<AssetEvent<Map>>,
+    pub map_event_reader: EventReader<AssetEvent<Map>>,
 }
 
 #[derive(Bundle)]

--- a/src/map.rs
+++ b/src/map.rs
@@ -555,6 +555,19 @@ impl Object {
     }
 }
 
+pub struct DebugConfig {
+    pub enabled: bool,
+    pub material: Handle<ColorMaterial>,
+}
+
+impl Default for DebugConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            material: Default::default(),
+        }
+    }
+}
 
 /// A bundle of tiled map entities.
 #[derive(Bundle)]
@@ -564,6 +577,7 @@ pub struct TiledMapComponents {
     pub atlases: HashMap<u32, Handle<TextureAtlas>>,
     pub origin: Transform,
     pub center: TiledMapCenter,
+    pub debug_config: DebugConfig,
 }
 
 impl Default for TiledMapComponents {
@@ -574,6 +588,7 @@ impl Default for TiledMapComponents {
             atlases: HashMap::default(),
             center: TiledMapCenter::default(),
             origin: Transform::default(),
+            debug_config: Default::default(),
         }
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -592,7 +592,7 @@ pub fn process_loaded_tile_maps(
                         );
                         let atlas_handle = texture_atlases.add(atlas);
                         for i in 0..(columns * rows) as u32 {
-                            println!("insert: {}", tileset.first_gid + i);
+                            // println!("insert: {}", tileset.first_gid + i);
                             texture_atlas_map.insert(tileset.first_gid + i, atlas_handle.clone());
                         }
                     }
@@ -661,7 +661,7 @@ pub fn process_loaded_tile_maps(
                 }
                 // TODO: use object_group.name, opacity, colour (properties)
                 for object in object_group.objects.iter() {
-                    println!("in object_group {}, object {}, grp: {}", object_group.name, &object.id, object.gid);
+                    // println!("in object_group {}, object {}, grp: {}", object_group.name, &object.id, object.gid);
                     let mut new_object = Object::new(object);
 
                     match &object.shape {

--- a/src/map.rs
+++ b/src/map.rs
@@ -580,9 +580,9 @@ impl Default for TiledMapComponents {
 
 #[derive(Default)]
 pub struct MapResourceProviderState {
-    pub map_event_reader: EventReader<AssetEvent<Map>>,
-    pub created_layer_entities: HashMap<u32, Vec<Entity>>,
-    pub created_object_entities: HashMap<u32, Vec<Entity>>,
+    map_event_reader: EventReader<AssetEvent<Map>>,
+    created_layer_entities: HashMap<u32, Vec<Entity>>,
+    created_object_entities: HashMap<u32, Vec<Entity>>,
 }
 
 #[derive(Bundle)]
@@ -739,9 +739,11 @@ pub fn process_loaded_tile_maps(
                         })
                         .collect::<Vec<_>>();
 
-                    state.created_layer_entities.get(&tileset_layer.tileset_guid).map(|entities| {
+                    // removing entities consumes the record of created entities
+                    state.created_layer_entities.remove(&tileset_layer.tileset_guid).map(|entities| {
                         // println!("Despawning previously-created mesh for this chunk");
                         for entity in entities.iter() {
+                            // println!("calling despawn on {:?}", entity);
                             commands.despawn(*entity);
                         }
                     });
@@ -770,9 +772,10 @@ pub fn process_loaded_tile_maps(
 
             for object_group in map.groups.iter() {
                 for object in object_group.objects.iter() {
-                    state.created_object_entities.get(&object.gid).map(|entities| {
+                    state.created_object_entities.remove(&object.gid).map(|entities| {
                         // println!("Despawning previously-created object sprite");
                         for entity in entities.iter() {
+                            // println!("calling despawn on {:?}", entity);
                             commands.despawn(*entity);
                         }
                     });

--- a/src/map.rs
+++ b/src/map.rs
@@ -400,19 +400,19 @@ impl Object {
     }
     fn transform(&self, map_transform: &Transform, map_orientation: tiled::Orientation, tile_size: Option<Vec2>) -> Transform{
         let mut transform = map_transform.clone();
-        let object_default_z = 10.0;
-        // transform.translation += Vec3::new(self.position.x, -self.position.y, 0.01);
+        // replacing map Z with something far in front for objects -- should probably be configurable
+        // transform.translation.z = 1000.0;
         match self.shape {
             tiled::ObjectShape::Rect { width, height } => {
                 let scale = tile_size.map(|ts| { Vec2::new(width, height) / ts });
                 match map_orientation {
                     tiled::Orientation::Orthogonal => {
-                        let mut center = Vec2::new(self.position.x + width / 2.0, -self.position.y + height / 2.0).extend(object_default_z);
+                        let mut center = Vec2::new(self.position.x + width / 2.0, -self.position.y + height / 2.0);
                         // apply map scale to object position
-                        center *= transform.scale;
+                        center *= transform.scale.truncate();
                         // replace scale with scale provided by object height/width - allow nonuniform (skew) with max original
                         transform.scale = scale.unwrap_or(Vec2::new(1.0, 1.0)).extend(1.0) * transform.scale.max_element();
-                        transform.translation += center;
+                        transform.translation += center.extend(-center.y / 100.0); // for layering properly, up = farther back
                     }
                     // tiled::Orientation::Isometric => {
                     // }

--- a/src/map.rs
+++ b/src/map.rs
@@ -495,7 +495,7 @@ impl Object {
         texture_atlas: Option<&Handle<TextureAtlas>>,
         map: &tiled::Map,
         tile_map_transform: &Transform,
-        debug_material: Handle<ColorMaterial>,
+        debug_config: &DebugConfig,
     ) -> &'a mut Commands {
         if let Some(texture_atlas) = texture_atlas {
             let sprite_index = self.sprite_index.expect("missing sprite index");
@@ -531,10 +531,11 @@ impl Object {
             commands
                 // Debug box.
                 .spawn(SpriteBundle {
-                    material: debug_material,
+                    material: debug_config.material.clone().unwrap_or_else(|| Handle::<ColorMaterial>::default()),
                     sprite: Sprite::new(dimensions),
                     transform,
                     visible: Visible {
+                        is_visible: debug_config.enabled,
                         is_transparent: true,
                         ..Default::default()
                     },
@@ -651,7 +652,7 @@ pub fn process_loaded_tile_maps(
         &mut HashMap<u32, Handle<ColorMaterial>>,
         &mut HashMap<u32, Handle<TextureAtlas>>,
         &Transform,
-        &DebugConfig,
+        &mut DebugConfig,
     )>,
 ) {
     let mut changed_maps = HashSet::<Handle<Map>>::default();
@@ -731,7 +732,7 @@ pub fn process_loaded_tile_maps(
         }
     }
 
-    for (_, center, map_handle, materials_map, texture_atlas_map, origin, debug_config) in query.iter_mut() {
+    for (_, center, map_handle, materials_map, texture_atlas_map, origin, mut debug_config) in query.iter_mut() {
         if new_meshes.contains_key(map_handle) {
             let map = maps.get(map_handle).unwrap();
 
@@ -786,7 +787,9 @@ pub fn process_loaded_tile_maps(
                 }
             }
 
-            let debug_material = debug_config.material.clone().unwrap_or_else(|| materials.add(ColorMaterial::from(Color::rgba(0.4, 0.4, 0.9, 0.5))));
+            if debug_config.enabled && debug_config.material.is_none() {
+                debug_config.material = Some(materials.add(ColorMaterial::from(Color::rgba(0.4, 0.4, 0.9, 0.5))));
+            }
             for object_group in map.groups.iter() {
                 for object in object_group.objects.iter() {
                     state.created_object_entities.remove(&object.gid).map(|entities| {
@@ -812,7 +815,7 @@ pub fn process_loaded_tile_maps(
                             atlas_handle,
                             &map.map,
                             &tile_map_transform,
-                            debug_material.clone(),
+                            &debug_config,
                         )
                         .current_entity().map(|entity| {
                             // when done spawning, fire event

--- a/src/map.rs
+++ b/src/map.rs
@@ -508,6 +508,7 @@ impl Object {
         commands: &'a mut Commands,
         texture_atlas: Option<&Handle<TextureAtlas>>,
         map: &tiled::Map,
+        map_handle: Handle<Map>,
         tile_map_transform: &Transform,
         debug_config: &DebugConfig,
     ) -> &'a mut Commands {
@@ -541,7 +542,6 @@ impl Object {
                     },
                     ..Default::default()
                 })
-                .with(self.clone())
         } else {
             // commands.spawn((self.map_transform(&map.map, &tile_map_transform, None), GlobalTransform::default()))
             let dimensions = self.dimensions().expect("Don't know how to handle object without dimensions");
@@ -559,8 +559,9 @@ impl Object {
                     },
                     ..Default::default()
                 })
-                .with(self.clone())
         }
+        .with(map_handle)
+        .with(self.clone())
     }
 
     pub fn dimensions(&self) -> Option<Vec2> {
@@ -629,6 +630,7 @@ pub struct CreatedMapEntities {
 
 #[derive(Bundle)]
 pub struct ChunkComponents {
+    pub map_parent: Handle<Map>, // tmp:chunks should be child entities of a toplevel map entity.
     pub chunk: TileMapChunk,
     pub main_pass: MainPass,
     pub material: Handle<ColorMaterial>,
@@ -643,6 +645,7 @@ pub struct ChunkComponents {
 impl Default for ChunkComponents {
     fn default() -> Self {
         Self {
+            map_parent: Handle::default(),
             chunk: TileMapChunk::default(),
             visible: Visible {
                 is_transparent: true,
@@ -806,6 +809,7 @@ pub fn process_loaded_tile_maps(
                             },
                             material: material_handle.clone(),
                             mesh: mesh.clone(),
+                            map_parent: map_handle.clone(),
                             transform: tile_map_transform.clone(),
                             ..Default::default()
                         }).current_entity().map(|new_entity| {
@@ -844,6 +848,7 @@ pub fn process_loaded_tile_maps(
                             commands,
                             atlas_handle,
                             &map.map,
+                            map_handle.clone(),
                             &tile_map_transform,
                             &debug_config,
                         )

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,20 +1,16 @@
 use anyhow::Result;
-use bevy::{
-    prelude::*,
-    render::mesh::Indices,
-    render::{
+use bevy::{prelude::*, render::mesh::Indices, render::{
+        draw::Visible,
         mesh::VertexAttributeValues,
         pipeline::PrimitiveTopology,
-        pipeline::{DynamicBinding, PipelineSpecialization, RenderPipeline},
+        pipeline::RenderPipeline,
         render_graph::base::MainPass,
-    },
-    utils::HashMap,
-};
-use bevy_type_registry::TypeUuid;
+    }, utils::{HashMap, HashSet}};
+use bevy_reflect::TypeUuid;
 
 use crate::{loader::TiledMapLoader, TileMapChunk, TILE_MAP_PIPELINE_HANDLE};
 use glam::Vec2;
-use std::{collections::HashSet, io::BufReader, path::Path};
+use std::{io::BufReader, path::Path};
 
 #[derive(Debug)]
 pub struct Tile {
@@ -55,25 +51,25 @@ pub struct Map {
 
 impl Map {
     pub fn project_ortho(pos: Vec2, tile_width: f32, tile_height: f32) -> Vec2 {
-        let x = tile_width * pos.x();
-        let y = tile_height * pos.y();
+        let x = tile_width * pos.x;
+        let y = tile_height * pos.y;
         Vec2::new(x, -y)
     }
     pub fn unproject_ortho(pos: Vec2, tile_width: f32, tile_height: f32) -> Vec2 {
-        let x = pos.x() / tile_width;
-        let y = -(pos.y()) / tile_height;
+        let x = pos.x / tile_width;
+        let y = -(pos.y) / tile_height;
         Vec2::new(x, y)
     }
     pub fn project_iso(pos: Vec2, tile_width: f32, tile_height: f32) -> Vec2 {
-        let x = (pos.x() - pos.y()) * tile_width / 2.0;
-        let y = (pos.x() + pos.y()) * tile_height / 2.0;
+        let x = (pos.x - pos.y) * tile_width / 2.0;
+        let y = (pos.x + pos.y) * tile_height / 2.0;
         Vec2::new(x, -y)
     }
     pub fn unproject_iso(pos: Vec2, tile_width: f32, tile_height: f32) -> Vec2 {
         let half_width = tile_width / 2.0;
         let half_height = tile_height / 2.0;
-        let x = ((pos.x() / half_width) + (-(pos.y()) / half_height)) / 2.0;
-        let y = ((-(pos.y()) / half_height) - (pos.x() / half_width)) / 2.0;
+        let x = ((pos.x / half_width) + (-(pos.y) / half_height)) / 2.0;
+        let y = ((-(pos.y) / half_height) - (pos.x / half_width)) / 2.0;
         Vec2::new(x.round(), y.round())
     }
     pub fn center(&self, origin: Transform) -> Transform {
@@ -81,13 +77,13 @@ impl Map {
         let map_center = Vec2::new(self.map.width as f32 / 2.0, self.map.height as f32 / 2.0);
         match self.map.orientation {
             tiled::Orientation::Orthogonal => {
-                let center = Map::project_ortho(map_center, tile_size.x(), tile_size.y());
+                let center = Map::project_ortho(map_center, tile_size.x, tile_size.y);
                 Transform::from_matrix(
                     origin.compute_matrix() * Mat4::from_translation(-center.extend(0.0)),
                 )
             }
             tiled::Orientation::Isometric => {
-                let center = Map::project_iso(map_center, tile_size.x(), tile_size.y());
+                let center = Map::project_iso(map_center, tile_size.x, tile_size.y);
                 Transform::from_matrix(
                     origin.compute_matrix() * Mat4::from_translation(-center.extend(0.0)),
                 )
@@ -179,16 +175,16 @@ impl Map {
                                             );
 
                                             let start = Vec2::new(
-                                                center.x() - tile_width / 2.0,
-                                                center.y() - tile_height / 2.0,
+                                                center.x - tile_width / 2.0,
+                                                center.y - tile_height / 2.0,
                                             );
 
                                             let end = Vec2::new(
-                                                center.x() + tile_width / 2.0,
-                                                center.y() + tile_height / 2.0,
+                                                center.x + tile_width / 2.0,
+                                                center.y + tile_height / 2.0,
                                             );
 
-                                            (start.x(), end.x(), start.y(), end.y())
+                                            (start.x, end.x, start.y, end.y)
                                         }
                                         tiled::Orientation::Isometric => {
                                             let center = Map::project_iso(
@@ -198,16 +194,16 @@ impl Map {
                                             );
 
                                             let start = Vec2::new(
-                                                center.x() - tile_width / 2.0,
-                                                center.y() - tile_height / 2.0,
+                                                center.x - tile_width / 2.0,
+                                                center.y - tile_height / 2.0,
                                             );
 
                                             let end = Vec2::new(
-                                                center.x() + tile_width / 2.0,
-                                                center.y() + tile_height / 2.0,
+                                                center.x + tile_width / 2.0,
+                                                center.y + tile_height / 2.0,
                                             );
 
-                                            (start.x(), end.x(), start.y(), end.y())
+                                            (start.x, end.x, start.y, end.y)
                                         }
                                         _ => {
                                             panic!("Unsupported orientation {:?}", map.orientation)
@@ -294,20 +290,20 @@ impl Map {
                             }
 
                             // X, Y
-                            positions.push([tile.vertex.x(), tile.vertex.y(), 0.0]);
-                            uvs.push([tile.uv.x(), tile.uv.w()]);
+                            positions.push([tile.vertex.x, tile.vertex.y, 0.0]);
+                            uvs.push([tile.uv.x, tile.uv.w]);
 
                             // X, Y + 1
-                            positions.push([tile.vertex.x(), tile.vertex.w(), 0.0]);
-                            uvs.push([tile.uv.x(), tile.uv.y()]);
+                            positions.push([tile.vertex.x, tile.vertex.w, 0.0]);
+                            uvs.push([tile.uv.x, tile.uv.y]);
 
                             // X + 1, Y + 1
-                            positions.push([tile.vertex.z(), tile.vertex.w(), 0.0]);
-                            uvs.push([tile.uv.z(), tile.uv.y()]);
+                            positions.push([tile.vertex.z, tile.vertex.w, 0.0]);
+                            uvs.push([tile.uv.z, tile.uv.y]);
 
                             // X + 1, Y
-                            positions.push([tile.vertex.z(), tile.vertex.y(), 0.0]);
-                            uvs.push([tile.uv.z(), tile.uv.w()]);
+                            positions.push([tile.vertex.z, tile.vertex.y, 0.0]);
+                            uvs.push([tile.uv.z, tile.uv.w]);
 
                             indices.extend_from_slice(&[i + 0, i + 2, i + 1, i + 0, i + 3, i + 2]);
 
@@ -375,6 +371,7 @@ pub struct ChunkComponents {
     pub main_pass: MainPass,
     pub material: Handle<ColorMaterial>,
     pub render_pipeline: RenderPipelines,
+    pub visible: Visible,
     pub draw: Draw,
     pub mesh: Handle<Mesh>,
     pub transform: Transform,
@@ -385,30 +382,16 @@ impl Default for ChunkComponents {
     fn default() -> Self {
         Self {
             chunk: TileMapChunk::default(),
-            draw: Draw {
+            visible: Visible {
                 is_transparent: true,
                 ..Default::default()
             },
+            draw: Default::default(),
             main_pass: MainPass,
             mesh: Handle::default(),
             material: Handle::default(),
-            render_pipeline: RenderPipelines::from_pipelines(vec![RenderPipeline::specialized(
-                TILE_MAP_PIPELINE_HANDLE,
-                PipelineSpecialization {
-                    dynamic_bindings: vec![
-                        // Transform
-                        DynamicBinding {
-                            bind_group: 2,
-                            binding: 0,
-                        },
-                        // Tile map chunk data
-                        DynamicBinding {
-                            bind_group: 2,
-                            binding: 1,
-                        },
-                    ],
-                    ..Default::default()
-                },
+            render_pipeline: RenderPipelines::from_pipelines(vec![RenderPipeline::new(
+                TILE_MAP_PIPELINE_HANDLE.typed()
             )]),
             transform: Default::default(),
             global_transform: Default::default(),
@@ -417,7 +400,7 @@ impl Default for ChunkComponents {
 }
 
 pub fn process_loaded_tile_maps(
-    mut commands: Commands,
+    commands: &mut Commands,
     asset_server: Res<AssetServer>,
     mut state: Local<MapResourceProviderState>,
     map_events: Res<Events<AssetEvent<Map>>>,
@@ -432,7 +415,7 @@ pub fn process_loaded_tile_maps(
         &Transform,
     )>,
 ) {
-    let mut changed_maps = HashSet::<Handle<Map>>::new();
+    let mut changed_maps = HashSet::<Handle<Map>>::default();
     for event in state.map_event_reader.iter(&map_events) {
         match event {
             AssetEvent::Created { handle } => {

--- a/src/map.rs
+++ b/src/map.rs
@@ -609,7 +609,7 @@ impl Default for TiledMapComponents {
 #[derive(Default)]
 pub struct MapResourceProviderState {
     map_event_reader: EventReader<AssetEvent<Map>>,
-    created_layer_entities: HashMap<u32, Vec<Entity>>,
+    created_layer_entities: HashMap<(usize, u32), Vec<Entity>>, // maps layer id and tileset_gid to mesh entities
     created_object_entities: HashMap<u32, Vec<Entity>>,
 }
 
@@ -769,7 +769,7 @@ pub fn process_loaded_tile_maps(
                         .collect::<Vec<_>>();
 
                     // removing entities consumes the record of created entities
-                    state.created_layer_entities.remove(&tileset_layer.tileset_guid).map(|entities| {
+                    state.created_layer_entities.remove(&(layer_id, tileset_layer.tileset_guid)).map(|entities| {
                         // println!("Despawning previously-created mesh for this chunk");
                         for entity in entities.iter() {
                             // println!("calling despawn on {:?}", entity);
@@ -792,7 +792,7 @@ pub fn process_loaded_tile_maps(
                             ..Default::default()
                         }).current_entity().map(|new_entity| {
                             // println!("added created_entry after spawn");
-                            state.created_layer_entities.entry(*tileset_guid)
+                            state.created_layer_entities.entry((layer_id, *tileset_guid))
                                 .or_insert_with(|| Vec::new()).push(new_entity);
                         });
                     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -1,7 +1,5 @@
 use crate::TileMapChunk;
-use bevy::{
-    prelude::*,
-    render::{
+use bevy::{prelude::*, render::{
         pipeline::{
             BlendDescriptor, BlendFactor, BlendOperation, ColorStateDescriptor, ColorWrite,
             CompareFunction, CullMode, DepthStencilStateDescriptor, FrontFace, PipelineDescriptor,
@@ -10,12 +8,11 @@ use bevy::{
         render_graph::{base, RenderGraph, RenderResourcesNode},
         shader::{ShaderStage, ShaderStages},
         texture::TextureFormat,
-    },
-};
-use bevy_type_registry::TypeUuid;
+    }};
+use bevy_reflect::TypeUuid;
 
-pub const TILE_MAP_PIPELINE_HANDLE: Handle<PipelineDescriptor> =
-    Handle::weak_from_u64(PipelineDescriptor::TYPE_UUID, 4129645945969645246);
+pub const TILE_MAP_PIPELINE_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(PipelineDescriptor::TYPE_UUID, 4129645945969645246);
 
 pub fn build_tile_map_pipeline(shaders: &mut Assets<Shader>) -> PipelineDescriptor {
     PipelineDescriptor {


### PR DESCRIPTION
This adds basic support for rectangular objects (including tile sprite objectes!) in Orthographic mode. We also add auto-reload support via asset events. 

**Note: this branch includes my other PR changes (tile rotation fix and dependent assets) as well as @framp's bevy 0.4.0 changes**
**if you want me to squash commits together to make it more mergeable, please LMK**

Objects without tile maps also may be made visible by way of passing the debug configuration object to the TiledMapComponents bundle:
```
debug_config: DebugConfig {
    enabled: true,
    ..Default::default()
},
```
When an object is created, it fires an ObjectReadyEvent event which includes the map asset handle and the entity ID for the newly-created object. This allows additional custom behavior in consuming application (e.g. collision).

I haven't done any testing/implementation of isometric, as I haven't been working with isometric maps in my project :)  

There isn't yet any support for round or polygon objects, but I wanted to do that next. Because it's hard to visualize and I like the bevy_tiled having the responsibility for spawning entities, I was going to add [lyon](https://github.com/Nilirad/bevy_prototype_lyon) as a dependency to allow debug visualizations of circle/polygon cases. However, I recognize how it might not make sense to open PRs after adding a new dependency, so I wanted to issue this PR first...

OTOH, if you like this direction, I will write up some documentation. and maybe find time to look at isometric objects.