### PR TITLE
Fix consistency with the XComponents -> XBundle refactor in bevy 0.4

### DIFF
--- a/examples/iso_main.rs
+++ b/examples/iso_main.rs
@@ -12,7 +12,7 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
-        .spawn(bevy_tiled_prototype::TiledMapComponents {
+        .spawn(bevy_tiled_prototype::TiledMapBundle {
             map_asset: asset_server.load("iso-map.tmx"),
             center: TiledMapCenter(true),
             origin: Transform::from_scale(Vec3::new(4.0, 4.0, 1.0)),

--- a/examples/ortho_debug.rs
+++ b/examples/ortho_debug.rs
@@ -17,7 +17,7 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
-        .spawn(bevy_tiled_prototype::TiledMapComponents {
+        .spawn(bevy_tiled_prototype::TiledMapBundle {
             map_asset: asset_server.load("ortho-map.tmx"),
             center: TiledMapCenter(true),
             origin: Transform::from_scale(Vec3::new(SCALE, SCALE, 1.0)),

--- a/examples/ortho_main.rs
+++ b/examples/ortho_main.rs
@@ -12,7 +12,7 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands
-        .spawn(bevy_tiled_prototype::TiledMapComponents {
+        .spawn(bevy_tiled_prototype::TiledMapBundle {
             map_asset: asset_server.load("ortho-map.tmx"),
             center: TiledMapCenter(true),
             origin: Transform::from_scale(Vec3::new(4.0, 4.0, 1.0)),

--- a/examples/parent_entity.rs
+++ b/examples/parent_entity.rs
@@ -30,7 +30,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         .current_entity();
 
     commands
-        .spawn(bevy_tiled_prototype::TiledMapComponents {
+        .spawn(bevy_tiled_prototype::TiledMapBundle {
             map_asset: asset_server.load("ortho-map.tmx"),
             parent_option: parent,
             center: TiledMapCenter(true),

--- a/src/map.rs
+++ b/src/map.rs
@@ -628,7 +628,7 @@ impl Default for DebugConfig {
 
 /// A bundle of tiled map entities.
 #[derive(Bundle)]
-pub struct TiledMapComponents {
+pub struct TiledMapBundle {
     pub map_asset: Handle<Map>,
     pub parent_option: Option<Entity>,
     pub materials: HashMap<u32, Handle<ColorMaterial>>,
@@ -639,7 +639,7 @@ pub struct TiledMapComponents {
     pub created_entities: CreatedMapEntities,
 }
 
-impl Default for TiledMapComponents {
+impl Default for TiledMapBundle {
     fn default() -> Self {
         Self {
             map_asset: Handle::default(),
@@ -663,7 +663,7 @@ pub struct CreatedMapEntities {
 }
 
 #[derive(Bundle)]
-pub struct ChunkComponents {
+pub struct ChunkBundle {
     pub map_parent: Handle<Map>, // tmp:chunks should be child entities of a toplevel map entity.
     pub chunk: TileMapChunk,
     pub main_pass: MainPass,
@@ -676,7 +676,7 @@ pub struct ChunkComponents {
     pub global_transform: GlobalTransform,
 }
 
-impl Default for ChunkComponents {
+impl Default for ChunkBundle {
     fn default() -> Self {
         Self {
             map_parent: Handle::default(),
@@ -870,7 +870,7 @@ pub fn process_loaded_tile_maps(
 
                         // Instead for now spawn a new entity per chunk.
                         let chunk_entity = commands
-                            .spawn(ChunkComponents {
+                            .spawn(ChunkBundle {
                                 chunk: TileMapChunk {
                                     // TODO: Support more layers here..
                                     layer_id: layer_id as f32,


### PR DESCRIPTION
This is a breaking change, but I think it's worth getting into a release targeting bevy 0.5 so that we're matching the conventions used in the rest of the bevy ecosystem.

context: https://github.com/bevyengine/bevy/pull/863