### PR TITLE
Updated APIs for objectgroup and get tiled objects via Map

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -26,7 +26,8 @@ pub struct Map {
     pub map: tiled::Map,
     pub meshes: Vec<(u32, u32, Mesh)>,
     pub layers: Vec<MapLayer>,
-    pub groups: Vec<ObjectGroup>,
+    pub groups: Vec<ObjectGroup>, // contains Objects
+    // pub tiles: Vec<Tile>,
     pub tile_size: Vec2,
     pub image_folder: std::path::PathBuf,
     pub asset_dependencies: Vec<PathBuf>,
@@ -423,7 +424,7 @@ pub fn process_loaded_tile_maps(
                             }
                         });
                 }
-                if !object_group.visible {
+                if !object_group.data.visible {
                     continue;
                 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,5 +1,5 @@
 use crate::{
-    objects::ObjectGroup, utils::project_iso, utils::project_ortho, ChunkBundle, MapLayer,
+    objects::Object, objects::ObjectGroup, utils::project_iso, utils::project_ortho, ChunkBundle, MapLayer,
     TileMapChunk, TilesetLayer,
 };
 use anyhow::Result;
@@ -53,6 +53,10 @@ impl Map {
         }
     }
 
+    pub fn tiled_object(&self, crate_obj: Object) -> &tiled::Object {
+        &self.map.object_groups[crate_obj.grp_idx].objects[crate_obj.obj_idx]
+    }
+
     pub fn try_from_bytes(asset_folder: &Path, asset_path: &Path, bytes: Vec<u8>) -> Result<Map> {
         #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
         let root_dir = bevy::asset::FileAssetIo::get_root_path();
@@ -77,9 +81,9 @@ impl Map {
         }
 
         let mut object_gids: HashSet<u32> = Default::default();
-        for object_group in map.object_groups.iter() {
+        for (i, object_group) in map.object_groups.iter().enumerate() {
             // recursively creates objects in the groups:
-            let tiled_o_g = ObjectGroup::new_with_tile_ids(object_group, &tile_gids);
+            let tiled_o_g = ObjectGroup::new_with_tile_ids(object_group, &tile_gids, i);
             // keep track of which objects will need to have tiles loaded
             tiled_o_g.objects.iter().for_each(|o| {
                 tile_gids.get(&o.gid).map(|first_gid| {

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -2,11 +2,26 @@ use bevy::{ecs::system::EntityCommands, prelude::*, utils::HashMap};
 
 use crate::{DebugConfig, Map};
 
+trait ShallowClone<T> {
+    fn shallow_clone(&self) -> Self;
+}
+impl ShallowClone<ObjectGroup> for tiled::ObjectGroup {
+    fn shallow_clone(&self) -> Self {
+        tiled::ObjectGroup {
+            name: self.name.to_owned(),
+            opacity: self.opacity,
+            visible: self.visible,
+            objects: Vec::default(),
+            colour: self.colour.clone(),
+            layer_index: self.layer_index.clone(),
+            properties: self.properties.clone(),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct ObjectGroup {
-    pub name: String,
-    pub opacity: f32,
-    pub visible: bool,
+    pub data: tiled::ObjectGroup,
     pub objects: Vec<Object>,
     idx: usize,
 }
@@ -19,10 +34,8 @@ impl ObjectGroup {
     ) -> ObjectGroup {
         // println!("grp {}", inner.name.to_string());
         ObjectGroup {
-            name: inner.name.to_string(),
             idx,
-            opacity: inner.opacity,
-            visible: inner.visible,
+            data: inner.shallow_clone(),
             objects: inner
                 .objects
                 .iter().enumerate()

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -8,22 +8,25 @@ pub struct ObjectGroup {
     pub opacity: f32,
     pub visible: bool,
     pub objects: Vec<Object>,
+    idx: usize,
 }
 
 impl ObjectGroup {
     pub fn new_with_tile_ids(
         inner: &tiled::ObjectGroup,
         tile_gids: &HashMap<u32, u32>,
+        idx: usize,
     ) -> ObjectGroup {
         // println!("grp {}", inner.name.to_string());
         ObjectGroup {
             name: inner.name.to_string(),
+            idx,
             opacity: inner.opacity,
             visible: inner.visible,
             objects: inner
                 .objects
-                .iter()
-                .map(|obj| Object::new_with_tile_ids(obj, tile_gids))
+                .iter().enumerate()
+                .map(|(i, obj)| Object::new_with_tile_ids(obj, tile_gids, i, idx))
                 .collect(),
         }
     }
@@ -41,10 +44,12 @@ pub struct Object {
     pub gid: u32,                 // sprite ID from tiled::Object
     pub tileset_gid: Option<u32>, // AKA first_gid
     pub sprite_index: Option<u32>,
+    pub(crate) grp_idx: usize,
+    pub(crate) obj_idx: usize,
 }
 
 impl Object {
-    pub fn new(original_object: &tiled::Object) -> Object {
+    pub fn new(original_object: &tiled::Object, grp_idx: usize, obj_idx: usize) -> Object {
         // println!("obj {} {}", original_object.name, original_object.visible.to_string());
         Object {
             shape: original_object.shape.clone(),
@@ -57,6 +62,8 @@ impl Object {
             size: Vec2::new(original_object.height, original_object.width),
             name: original_object.name.clone(),
             obj_type: original_object.obj_type.clone(),
+            grp_idx,
+            obj_idx,
         }
     }
 
@@ -67,9 +74,11 @@ impl Object {
     pub fn new_with_tile_ids(
         original_object: &tiled::Object,
         tile_gids: &HashMap<u32, u32>,
+        idx: usize,
+        grp_idx: usize,
     ) -> Object {
         // println!("obj {}", original_object.gid.to_string());
-        let mut o = Object::new(original_object);
+        let mut o = Object::new(original_object, grp_idx, idx);
         o.set_tile_ids(tile_gids);
         o
     }


### PR DESCRIPTION
Considering a couple new APIs for https://github.com/StarArawn/bevy_tiled/issues/56

We're cloning objects to include use as entities, so I don't just want to clone the contents of the rs-tiled structs there. There are two examples here:
- passing the Object or (future) Map entity a map.map asset to retrieve the original data (could also work well as an impl-ed trait on the tiled::map) that takes bevy_tiled objects.
- cloning part of tiled structures, in the case of

I'm less worried about cloning object groups, especially shallow-cloned, but I figure there might be orders of magnitude more objects if we improve our spawning API. @rparrett and others -- lmk what you think.